### PR TITLE
Resolve alguns problemas que ainda não existem

### DIFF
--- a/twitterBot.php
+++ b/twitterBot.php
@@ -175,15 +175,19 @@
 	}
 	
 	function trim_punctuation($phrase){
-		return str_replace(array("?","!",",",";","."), "", $phrase);
+		return str_replace(array("?","!",",",";","."), " ", $phrase);
 	}
-	
+
+	function trim_extra_spaces($phrase){
+		return trim(preg_replace('/\s\s+/', ' ', str_replace("\n", " ", $phrase)));
+	}
+
 	function normalize_url_param_value($value){
 		return rawurlencode(trim_punctuation(trim_articles($value)));
 	}
 	
 	function normalize_tweet($tweet){
-		return stripAccents(mb_strtolower($tweet, 'UTF-8'));
+		return trim_extra_spaces(stripAccents(mb_strtolower($tweet, mb_detect_encoding($tweet))));
 	}
 	
 	function choose_phrase($arr_phrases){


### PR DESCRIPTION
"Mas qual a sua orientação?Marxista?"
ao remover a pontuação, ela vai encontrar "orientaçãomarxista" e não vai mandar nada. Então está trocando as pontuações por espaços.
Mas se a pessoa escreve direito, então ela vai ter dois espaços. Então removi duplo espaçamento.

Tb alterei "UTF-8" para uma função que detecta automaticamente o encoding, pra nunca ter erro.